### PR TITLE
feat: Add /suggest API for friend recommendations

### DIFF
--- a/db/db.ts
+++ b/db/db.ts
@@ -130,5 +130,19 @@ export const dbOps = {
         DELETE FROM "users"
         WHERE email=$1
         RETURNING *;
+        `,
+    getUserById: `
+        SELECT id, first_name, last_name, email
+        FROM "users"
+        WHERE "id"=$1;
+        `,
+    getAcceptedFriendsById: `
+        SELECT u.id, u.first_name, u.last_name, u.email
+        FROM "user_friends" uf
+        JOIN "users" u ON (CASE
+                            WHEN uf.user_id = $1 THEN uf.friend_id = u.id
+                            WHEN uf.friend_id = $1 THEN uf.user_id = u.id
+                          END)
+        WHERE (uf.user_id = $1 OR uf.friend_id = $1) AND uf.accepted = TRUE;
         `
 }


### PR DESCRIPTION
Implements a new POST API endpoint /suggest that provides friend suggestions for you.

The suggestion logic is based on "friends of friends":
- Takes your email as input.
- Identifies your direct friends (connections where accepted = TRUE).
- Finds the friends of those direct friends.
- Filters out you and anyone you are already friends with from the "friends of friends" list.
- Returns a list of unique suggested users, including their ID, first name, last name, and email.

New database queries added to `db/db.ts`:
- `getUserById`: Fetches user details by their ID.
- `getAcceptedFriendsById`: Retrieves a list of accepted friends for a given user ID, correctly handling relationship direction in the `user_friends` table.

The `/suggest` endpoint in `src/app.ts` is protected by authentication (`isLoggedIn`) and includes error handling for invalid input or server issues.